### PR TITLE
Add new workshops

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,4 +1,15 @@
 {
+  "new": {
+    "title": "New workshops",
+    "description": "The new additions to the Hack Club workshops",
+    "slugs": [
+      "teachable_machine",
+      "splatter_paint",
+      "colorful_grammar",
+      "sound_galaxy",
+      "rick_roll"
+    ]
+  },
   "starters": {
     "title": "Start here",
     "description": "Set out on your journey by building your own website, then move on to multiplayer games and collaborative web apps.",


### PR DESCRIPTION
Adds Teachable Machine, Splatter Paint, Colorful Grammar, Sound Galaxy, and Rickroll to a new “New workshops” section