### PR TITLE
Take rickroll out of commission :(

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
       "colorful_grammar",
       "speak_colors",
       "sound_galaxy",
-      "rick_roll"
+      "teachable_machine"
     ]
   },
   "web": {


### PR DESCRIPTION
Nexmo rebranded to Vonage and changed their API to be a lot less friendly to people who don't give them their credit card info, so it has to be taken out of commission for now. I think SMS workshops are super cool though, so I would love to explore an official Hack Club Vonage number that we pay for and can offer to leaders running SMS-based workshops