### PR TITLE
`@hackclub/markdown` to 0.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@hackclub/banner": "^1.0.1",
-    "@hackclub/markdown": "^0.0.4",
+    "@hackclub/markdown": "^0.0.3",
     "@hackclub/meta": "^1.0.0",
     "@hackclub/theme": "^0.3.0",
     "@mdx-js/loader": "^1.6.19",


### PR DESCRIPTION
v0.0.4 doesn't exist which is why the build is failing
<img width="553" alt="Screen Shot 2021-11-22 at 9 13 14 PM" src="https://user-images.githubusercontent.com/72365100/142974515-b6d63a7e-783e-4bce-8d28-bf7f51070ee1.png">

