### PR TITLE
Add Thunderstorm workshop

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -64,7 +64,8 @@
       "kuizzy",
       "painting_app",
       "website_mockup_generator",
-      "meme_generator"
+      "meme_generator",
+      "thunderstorm"
     ]
   },
   "games": {


### PR DESCRIPTION
https://workshops.hackclub.com/thunderstorm/

There may be a reason it was removed (in that case, feel free to close this PR)

This PR adds the Thunderstorm workshop to the workshops page. It seems like a fun workshop.

<img width="507" alt="Screen Shot 2022-03-10 at 01 26 39" src="https://user-images.githubusercontent.com/72365100/157631794-21b37e71-3cad-44bd-a1db-67c5860be951.png">

https://hackclub.slack.com/archives/C02AWNTDXUH/p1646903853100569