### PR TITLE
Remove mentions to me on the submit a workshop page

### DIFF
--- a/pages/submit-a-workshop.mdx
+++ b/pages/submit-a-workshop.mdx
@@ -17,6 +17,8 @@ Nearly every [Hack Club Workshop](https://workshops.hackclub.com) was written an
 
 If I can answer any questions or be helpful in any way, please feel free to DM me on Slack.
 
+*Update: I no longer work at Hack Club—for questions, please post in `#leaders` or DM <StaticMention username="leo" avatar="https://ca.slack-edge.com/T0266FRGM-U022FMN61SB-e99ec674b6d4-512" link="" />.*
+
 ## Submission requirements
 
 - You must be a club leader or an active community member in order to submit a workshop.
@@ -35,7 +37,7 @@ If I can answer any questions or be helpful in any way, please feel free to DM m
   - ❌ A workshop on making an Android app that requires installing Android Studio
 - At the beginning of your workshop, you must include the link to the final demo and the final code.
 - Your workshop must be in English at native-level proficiency. Phrasing and grammar must be perfect.
-- By default, all workshops should be written in Markdown or another format that can be easily be added to the [Workshops page](https://workshops.hackclub.com). Workshops submitted in a different format are also encouraged, but the format must be approved by <StaticMention username="matthew" avatar="https://cloud-7kduganuu-hack-club-bot.vercel.app/0img_5187.jpg" link="https://matthewstanciu.me/" /> first.
+- By default, all workshops should be written in Markdown or another format that can be easily be added to the [Workshops page](https://workshops.hackclub.com). Workshops submitted in a different format are also encouraged, but the format must be approved by <StaticMention username="leo" avatar="https://ca.slack-edge.com/T0266FRGM-U022FMN61SB-e99ec674b6d4-512" link="" /> first.
 - Each step in your workshop should be very clearly explained and should continually give context for where the user is in the workshop.
   - ✅ [Konami Code](https://workshops.hackclub.com/konami_code/): each step contains a small block of code that is clearly explained right afterward. Phrases such as "just above the closing `</body>` tag", code blocks that include new lines of code being shown in their entirety, and a constant reminder of what the current code should look like, all make sure the person going through the workshop is never lost. Any code concepts or information about a library are made optional to learn more by clicking a link.
   - ❌ A workshop that includes many large blocks of code for the user to copy/paste, and does not explain what much of the code does


### PR DESCRIPTION
I noticed this page still instructed people to DM me with questions or get workshop ideas approved by me. This PR removes & replaces those mentions with Leo.