### PR TITLE
Add community newsletters page

### DIFF
--- a/components/newsletters.js
+++ b/components/newsletters.js
@@ -1,13 +1,12 @@
 import { Grid, Card, useThemeUI } from 'theme-ui'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import { formatTitle } from '../lib/format-title'
 
 const colors = 'red,orange,yellow,green,cyan,blue,purple'.split(',')
 const getColor = i => colors[Number(i - 1) % colors.length]
 
-function capitalize(str) {
-  return str.charAt(0).toUpperCase() + str.toLowerCase().slice(1)
-}
+
 
 export default ({ issues, showAbout, vip = true }) => {
   const { pathname, query } = useRouter()
@@ -71,11 +70,7 @@ export default ({ issues, showAbout, vip = true }) => {
                         : theme.shadows.card
                   }}
                 >
-                  {capitalize(issue.split('-')[2]) +
-                    ' ' +
-                    issue.split('-')[1] +
-                    ', ' +
-                    issue.split('-')[0]}
+                  {formatTitle(issue)}
                 </Card>
               </Link>
             ))}

--- a/components/newsletters.js
+++ b/components/newsletters.js
@@ -6,74 +6,37 @@ import { formatTitle } from '../lib/format-title'
 const colors = 'red,orange,yellow,green,cyan,blue,purple'.split(',')
 const getColor = i => colors[Number(i - 1) % colors.length]
 
-
-
 export default ({ issues, showAbout, vip = true }) => {
   const { pathname, query } = useRouter()
-  const active =
-    pathname.startsWith('/vip-newsletters/') ||
-    pathname.startsWith('/newsletters/')
-      ? query.slug
-      : false
+  const active = pathname.startsWith('/vip-newsletters/') || pathname.startsWith('/newsletters/') ? query.slug : false
   const { theme } = useThemeUI()
   return (
     <>
-      <Grid
-        columns={vip ? [2, 3, 4] : [2, 3]}
-        gap={3}
-        sx={{ alignItems: 'center' }}
-      >
-        {vip
-          ? // VIP newsletter styles
-            issues.map(issue => (
-              <Link
-                href={`/vip-newsletters/[slug]`}
-                as={`/vip-newsletters/${issue}`}
-                passHref
-                key={issue}
-              >
-                <Card
-                  as="a"
-                  variant="nav"
-                  sx={{ bg: getColor(issue), color: 'white' }}
-                  style={{
-                    boxShadow:
-                      active === issue
-                        ? `0 0 0 3px ${theme.colors.sheet}, 0 0 0 6px ${
-                            theme.colors[getColor(issue)]
-                          }`
-                        : theme.shadows.card
-                  }}
-                >
-                  {issue}
-                </Card>
-              </Link>
-            ))
-          : // Community news letter issues
-            issues.map((issue, i) => (
-              <Link
-                href={`/newsletters/[slug]`}
-                as={`/newsletters/${issue}`}
-                passHref
-                key={issue}
-              >
-                <Card
-                  as="a"
-                  variant="nav"
-                  sx={{ bg: getColor(i+1), color: 'white' }}
-                  style={{
-                    boxShadow:
-                      active === i+1
-                        ? `0 0 0 3px ${theme.colors.sheet}, 0 0 0 6px ${
-                            theme.colors[getColor(i+1)]
-                          }`
-                        : theme.shadows.card
-                  }}
-                >
-                  {formatTitle(issue)}
-                </Card>
-              </Link>
-            ))}
+      <Grid columns={[2, 3, 4]} gap={3} sx={{ alignItems: 'center' }}>
+        {issues.map((issue, i) => (
+          <Link
+            href={`/${vip ? 'vip-' : ''}newsletters/[slug]`}
+            as={`/${vip ? 'vip-' : ''}newsletters/${issue}`}
+            passHref
+            key={issue}
+          >
+            <Card
+              as="a"
+              variant="nav"
+              sx={{ bg: getColor(i+1), color: 'white' }}
+              style={{
+                boxShadow:
+                  active === i+1
+                    ? `0 0 0 3px ${theme.colors.sheet}, 0 0 0 6px ${
+                        theme.colors[getColor(i+1)]
+                      }`
+                    : theme.shadows.card
+              }}
+            >
+              {vip ? issue : formatTitle(issue)}
+            </Card>
+          </Link>
+        ))}
       </Grid>
     </>
   )

--- a/components/newsletters.js
+++ b/components/newsletters.js
@@ -7,35 +7,66 @@ const getColor = i => colors[Number(i - 1) % colors.length]
 
 export default ({ issues, showAbout, vip = true }) => {
   const { pathname, query } = useRouter()
-  const active = pathname.startsWith('/vip-newsletters/') || pathname.startsWith('/newsletters/') ? query.slug : false
+  const active =
+    pathname.startsWith('/vip-newsletters/') ||
+    pathname.startsWith('/newsletters/')
+      ? query.slug
+      : false
   const { theme } = useThemeUI()
   return (
     <>
-      <Grid columns={[2, 3, 4]} gap={3} sx={{ alignItems: 'center' }}>
-        {issues.map(issue => (
-          <Link
-            href={`/${vip ? 'vip-' : ''}newsletters/[slug]`}
-            as={`/${vip ? 'vip-' : ''}newsletters/${issue}`}
-            passHref
-            key={issue}
-          >
-            <Card
-              as="a"
-              variant="nav"
-              sx={{ bg: getColor(issue), color: 'white' }}
-              style={{
-                boxShadow:
-                  active === issue
-                    ? `0 0 0 3px ${theme.colors.sheet}, 0 0 0 6px ${
-                        theme.colors[getColor(issue)]
-                      }`
-                    : theme.shadows.card
-              }}
-            >
-              {issue}
-            </Card>
-          </Link>
-        ))}
+      <Grid columns={vip ? [2, 3, 4] : [2, 3]} gap={3} sx={{ alignItems: 'center' }}>
+        {vip
+          // VIP newsletter styles
+          ? issues.map(issue => (
+              <Link
+                href={`/vip-newsletters/[slug]`}
+                as={`/vip-newsletters/${issue}`}
+                passHref
+                key={issue}
+              >
+                <Card
+                  as="a"
+                  variant="nav"
+                  sx={{ bg: getColor(issue), color: 'white' }}
+                  style={{
+                    boxShadow:
+                      active === issue
+                        ? `0 0 0 3px ${theme.colors.sheet}, 0 0 0 6px ${
+                            theme.colors[getColor(issue)]
+                          }`
+                        : theme.shadows.card
+                  }}
+                >
+                  {issue}
+                </Card>
+              </Link>
+            ))
+          // Community news letter issues
+          : issues.map(issue => (
+              <Link
+                href={`/newsletters/[slug]`}
+                as={`/newsletters/${issue}`}
+                passHref
+                key={issue}
+              >
+                <Card
+                  as="a"
+                  variant="nav"
+                  sx={{ bg: getColor(issue), color: 'white' }}
+                  style={{
+                    boxShadow:
+                      active === issue
+                        ? `0 0 0 3px ${theme.colors.sheet}, 0 0 0 6px ${
+                            theme.colors[getColor(issue)]
+                          }`
+                        : theme.shadows.card
+                  }}
+                >
+                  {issue}
+                </Card>
+              </Link>
+            ))}
       </Grid>
     </>
   )

--- a/components/newsletters.js
+++ b/components/newsletters.js
@@ -50,7 +50,7 @@ export default ({ issues, showAbout, vip = true }) => {
               </Link>
             ))
           : // Community news letter issues
-            issues.map(issue => (
+            issues.map((issue, i) => (
               <Link
                 href={`/newsletters/[slug]`}
                 as={`/newsletters/${issue}`}
@@ -60,12 +60,12 @@ export default ({ issues, showAbout, vip = true }) => {
                 <Card
                   as="a"
                   variant="nav"
-                  sx={{ bg: getColor(issue), color: 'white' }}
+                  sx={{ bg: getColor(i+1), color: 'white' }}
                   style={{
                     boxShadow:
-                      active === issue
+                      active === i+1
                         ? `0 0 0 3px ${theme.colors.sheet}, 0 0 0 6px ${
-                            theme.colors[getColor(issue)]
+                            theme.colors[getColor(i+1)]
                           }`
                         : theme.shadows.card
                   }}

--- a/components/newsletters.js
+++ b/components/newsletters.js
@@ -5,6 +5,10 @@ import { useRouter } from 'next/router'
 const colors = 'red,orange,yellow,green,cyan,blue,purple'.split(',')
 const getColor = i => colors[Number(i - 1) % colors.length]
 
+function capitalize(str) {
+  return str.charAt(0).toUpperCase() + str.toLowerCase().slice(1)
+}
+
 export default ({ issues, showAbout, vip = true }) => {
   const { pathname, query } = useRouter()
   const active =
@@ -15,10 +19,14 @@ export default ({ issues, showAbout, vip = true }) => {
   const { theme } = useThemeUI()
   return (
     <>
-      <Grid columns={vip ? [2, 3, 4] : [2, 3]} gap={3} sx={{ alignItems: 'center' }}>
+      <Grid
+        columns={vip ? [2, 3, 4] : [2, 3]}
+        gap={3}
+        sx={{ alignItems: 'center' }}
+      >
         {vip
-          // VIP newsletter styles
-          ? issues.map(issue => (
+          ? // VIP newsletter styles
+            issues.map(issue => (
               <Link
                 href={`/vip-newsletters/[slug]`}
                 as={`/vip-newsletters/${issue}`}
@@ -42,8 +50,8 @@ export default ({ issues, showAbout, vip = true }) => {
                 </Card>
               </Link>
             ))
-          // Community news letter issues
-          : issues.map(issue => (
+          : // Community news letter issues
+            issues.map(issue => (
               <Link
                 href={`/newsletters/[slug]`}
                 as={`/newsletters/${issue}`}
@@ -63,7 +71,11 @@ export default ({ issues, showAbout, vip = true }) => {
                         : theme.shadows.card
                   }}
                 >
-                  {issue}
+                  {capitalize(issue.split('-')[2]) +
+                    ' ' +
+                    issue.split('-')[1] +
+                    ', ' +
+                    issue.split('-')[0]}
                 </Card>
               </Link>
             ))}

--- a/lib/data.js
+++ b/lib/data.js
@@ -60,13 +60,8 @@ const authorsQuery = gql`
           history(first: 100, path: $issue) {
             nodes {
               author {
-                email
-                name
                 user {
-                  name
-                  avatarUrl
                   login
-                  url
                 }
               }
             }
@@ -137,13 +132,18 @@ export const getNewsletterSlugs = async () =>
     .map(x => x.name)
     .filter(path => !['.gitignore', 'README.md'].includes(path))
 
-export const getNewsLetterAuthors = async (issue) => (
-  await client.request(authorsQuery, {
-    owner: 'hackclub',
-    name: 'newsletter',
-    issue: issue
-  })
-).repository.object.history.nodes
+export const getNewsletterAuthors = async slug => {
+  const authors = (
+    await client.request(authorsQuery, {
+      owner: 'hackclub',
+      name: 'newsletter',
+      issue: slug
+    })
+  ).repository.object.history.nodes
+
+
+  return [...new Set(authors.map(author => "@" + author.author.user.login))]
+}
 
 export const getNewsletterFile = async slug =>
   await getRawFileFromRepo(`/${slug}/README.md`, 'main', 'hackclub/newsletter')

--- a/lib/data.js
+++ b/lib/data.js
@@ -52,6 +52,31 @@ const newsletterQuery = gql`
   }
 `
 
+const authorsQuery = gql`
+  query RepoOwners($owner: String!, $name: String!, $issue: String!) {
+    repository(owner: $owner, name: $name) {
+      object(expression: "main") {
+        ... on Commit {
+          history(first: 100, path: $issue) {
+            nodes {
+              author {
+                email
+                name
+                user {
+                  name
+                  avatarUrl
+                  login
+                  url
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`
+
 export const client = new GraphQLClient('https://api.github.com/graphql', {
   headers: {
     Authorization: `Bearer ${process.env.GITHUB}`
@@ -69,18 +94,20 @@ export const getWorkshopSlugs = async () =>
     .filter(path => !['img', 'lib', 'README.md'].includes(path))
 
 export const getWorkshopFile = async (slug, locale) => {
-  const result = await getRawFileFromRepo(`/workshops/${slug}/${locale ? locale : "README"}.md`)
-  return result;
+  const result = await getRawFileFromRepo(
+    `/workshops/${slug}/${locale ? locale : 'README'}.md`
+  )
+  return result
 }
-  
+
 export const getVIPNewsletterSlugs = async () =>
-  (await(
-    client.request(newsletterQuery, {
+  (
+    await client.request(newsletterQuery, {
       owner: 'hackclub',
       name: 'vip-newsletters'
     })
-  ))
-    .repository.object.entries.map(x => x.name)
+  ).repository.object.entries
+    .map(x => x.name)
     .filter(path => !['.gitignore', 'README.md'].includes(path))
 
 export const getVIPNewsletterFile = async slug =>
@@ -101,21 +128,25 @@ export const getVIPNewslettersHtml = async () => {
 }
 
 export const getNewsletterSlugs = async () =>
-  (await(
-    client.request(newsletterQuery, {
+  (
+    await client.request(newsletterQuery, {
       owner: 'hackclub',
       name: 'newsletter'
     })
-  ))
-    .repository.object.entries.map(x => x.name)
+  ).repository.object.entries
+    .map(x => x.name)
     .filter(path => !['.gitignore', 'README.md'].includes(path))
 
+export const getNewsLetterAuthors = async (issue) => (
+  await client.request(authorsQuery, {
+    owner: 'hackclub',
+    name: 'newsletter',
+    issue: issue
+  })
+).repository.object.history.nodes
+
 export const getNewsletterFile = async slug =>
-  await getRawFileFromRepo(
-    `/${slug}/README.md`,
-    'main',
-    'hackclub/newsletter'
-  )
+  await getRawFileFromRepo(`/${slug}/README.md`, 'main', 'hackclub/newsletter')
 
 export const getNewslettersHtml = async () => {
   const md = await getRawFileFromRepo(
@@ -223,12 +254,9 @@ export const getVIPNewsletterData = async (slug, md) => {
   return { data, html }
 }
 
-
 export const getNewsletterData = async (slug, md) => {
   const avatars = ['quackduck']
-    .map(
-      n => `images=${encodeURIComponent('https://github.com/')}${n}.png`
-    )
+    .map(n => `images=${encodeURIComponent('https://github.com/')}${n}.png`)
     .join('&')
   const img = `https://workshop-cards.hackclub.com/Newsletter%20${slug}.png?brand=HQ&${avatars}`
   const data = {

--- a/lib/format-title.js
+++ b/lib/format-title.js
@@ -3,11 +3,5 @@ export function capitalize(str) {
 }
 
 export function formatTitle(str) {
-  return (
-    capitalize(str.split('-')[2]) +
-    ' ' +
-    str.split('-')[1] +
-    ', ' +
-    str.split('-')[0]
-  )
+  return capitalize(str.split('-')[2]) + ' ' + str.split('-')[0]
 }

--- a/lib/format-title.js
+++ b/lib/format-title.js
@@ -1,0 +1,13 @@
+export function capitalize(str) {
+  return str.charAt(0).toUpperCase() + str.toLowerCase().slice(1)
+}
+
+export function formatTitle(str) {
+  return (
+    capitalize(str.split('-')[2]) +
+    ' ' +
+    str.split('-')[1] +
+    ', ' +
+    str.split('-')[0]
+  )
+}

--- a/pages/newsletters/[slug].js
+++ b/pages/newsletters/[slug].js
@@ -11,7 +11,7 @@ import { GitHub, HelpCircle, ArrowLeftCircle } from 'react-feather'
 import { useRouter } from 'next/router'
 import { formatTitle } from '../../lib/format-title'
 
-const Page = ({ issues, slug, data, html }) => {
+const Page = ({ issues, slug, data, html, authors }) => {
   const router = useRouter()
   if (router.isFallback) {
     return (
@@ -29,7 +29,11 @@ const Page = ({ issues, slug, data, html }) => {
   if (!slug || !data) return <Error statusCode={404} />
   return (
     <>
-      <Header title="Community Newsletter" />
+      <Header title="Community Newsletter">
+        <Heading sx={{ mt: 3, mb: 2 }}>{formatTitle(slug)}</Heading>
+        <Authors text={authors.join()} />
+        {/* <Heading sx={{fontSize: } }></Heading> */}
+      </Header>
       <Container variant="copy" as="main" pb={4}>
         <Link href="/newsletters" passHref>
           <Box
@@ -102,15 +106,17 @@ export const getStaticProps = async ({ params }) => {
   const {
     getNewsletterSlugs,
     getNewsletterFile,
-    getNewsletterData
+    getNewsletterData,
+    getNewsletterAuthors
   } = require('../../lib/data')
   const { slug } = params
   const issues = await getNewsletterSlugs()
   const md = await getNewsletterFile(slug)
   const { data, html } = await getNewsletterData(slug, md)
-  data.title =
-    data.title.split(' ')[0] + ' ' + formatTitle(data.title.split(' ')[1])
-  return { props: { issues, slug, data, html }, revalidate: 30 }
+  data.title = data.title.split(' ')[0] + ' ' + formatTitle(data.title.split(' ')[1])
+  const authors = await getNewsletterAuthors(slug)
+
+  return { props: { issues, slug, data, html, authors }, revalidate: 30 }
 }
 
 export default Page

--- a/pages/newsletters/[slug].js
+++ b/pages/newsletters/[slug].js
@@ -9,6 +9,7 @@ import Content from '../../components/content'
 import { NavButton } from '../../components/nav'
 import { GitHub, HelpCircle } from 'react-feather'
 import { useRouter } from 'next/router'
+import { formatTitle } from '../../lib/format-title'
 
 const Page = ({ issues, slug, data, html }) => {
   const router = useRouter()
@@ -26,6 +27,7 @@ const Page = ({ issues, slug, data, html }) => {
     )
   }
   if (!slug || !data) return <Error statusCode={404} />
+  console.log(data)
   return (
     <>
       <Header {...data} includeMeta />
@@ -96,6 +98,8 @@ export const getStaticProps = async ({ params }) => {
   const issues = await getNewsletterSlugs()
   const md = await getNewsletterFile(slug)
   const { data, html } = await getNewsletterData(slug, md)
+  data.title =
+    data.title.split(' ')[0] + ' ' + formatTitle(data.title.split(' ')[1])
   return { props: { issues, slug, data, html }, revalidate: 30 }
 }
 

--- a/pages/newsletters/[slug].js
+++ b/pages/newsletters/[slug].js
@@ -59,31 +59,29 @@ const Page = ({ issues, slug, data, html }) => {
         <Container>
           <Flex
             sx={{
-              mb: 3,
-              flexWrap: 'wrap',
-              alignItems: 'flex-end',
+              mb: 5,
+              alignContent: 'center',
               justifyContent: 'center',
-              textAlign: 'center'
+              textAlign: 'center',
+              flexDirection: 'column'
             }}
           >
             <Heading variant="headline" mt={0} mr={3} mb={2}>
               Recent issues
             </Heading>
             <Link href="/newsletters" passHref>
-              <NavButton
-                as="a"
-                color="muted"
+              <Container
                 sx={{
-                  display: 'inline-flex',
-                  width: 'auto',
-                  pr: 2,
-                  mb: 2,
-                  svg: { mr: 2 }
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  color: 'muted',
+                  ':hover': { cursor: 'pointer' }
                 }}
               >
                 <HelpCircle size={24} />
-                What are these?
-              </NavButton>
+                <Heading sx={{ ml: 2 }}>What are these?</Heading>
+              </Container>
             </Link>
           </Flex>
           <Issues issues={issues} vip={false} showAbout />

--- a/pages/newsletters/[slug].js
+++ b/pages/newsletters/[slug].js
@@ -31,15 +31,29 @@ const Page = ({ issues, slug, data, html, authors }) => {
     <>
       <Header title="Community Newsletter">
         <Heading sx={{ mt: 3, mb: 2 }}>{formatTitle(slug)}</Heading>
-        <Authors text={authors.join()} />
-        {/* <Heading sx={{fontSize: } }></Heading> */}
+        <Authors text={authors.join()} color="secondary" />
+        <Heading sx={{ fontSize: 1, color: 'secondary', mt: 3 }}>
+          Want to be an author? Submit a pull request{' '}
+          <Link href="https://github.com/hackclub/newsletter" passHref>
+            <Heading
+              sx={{
+                display: 'inline',
+                fontSize: 1,
+                color: 'red',
+                ':hover': { cursor: 'pointer' }
+              }}
+            >
+              here!
+            </Heading>
+          </Link>
+        </Heading>
       </Header>
       <Container variant="copy" as="main" pb={4}>
         <Link href="/newsletters" passHref>
           <Box
             sx={{
               mb: 4,
-              display: 'flex',
+              display: 'inline-flex',
               alignItems: 'center',
               ':hover': { color: 'red', cursor: 'pointer' }
             }}
@@ -113,7 +127,8 @@ export const getStaticProps = async ({ params }) => {
   const issues = await getNewsletterSlugs()
   const md = await getNewsletterFile(slug)
   const { data, html } = await getNewsletterData(slug, md)
-  data.title = data.title.split(' ')[0] + ' ' + formatTitle(data.title.split(' ')[1])
+  data.title =
+    data.title.split(' ')[0] + ' ' + formatTitle(data.title.split(' ')[1])
   const authors = await getNewsletterAuthors(slug)
 
   return { props: { issues, slug, data, html, authors }, revalidate: 30 }

--- a/pages/newsletters/[slug].js
+++ b/pages/newsletters/[slug].js
@@ -1,5 +1,5 @@
 import { map } from 'lodash'
-import { Box, Container, Heading, Flex, Button, Spinner } from 'theme-ui'
+import { Box, Container, Heading, Flex, Button, Spinner, Text } from 'theme-ui'
 import Error from 'next/error'
 import Link from 'next/link'
 import Header from '../../components/header'
@@ -7,7 +7,7 @@ import Authors from '../../components/authors'
 import Issues from '../../components/newsletters'
 import Content from '../../components/content'
 import { NavButton } from '../../components/nav'
-import { GitHub, HelpCircle } from 'react-feather'
+import { GitHub, HelpCircle, ArrowLeftCircle } from 'react-feather'
 import { useRouter } from 'next/router'
 import { formatTitle } from '../../lib/format-title'
 
@@ -27,11 +27,23 @@ const Page = ({ issues, slug, data, html }) => {
     )
   }
   if (!slug || !data) return <Error statusCode={404} />
-  console.log(data)
   return (
     <>
-      <Header {...data} includeMeta />
+      <Header title="Community Newsletter" />
       <Container variant="copy" as="main" pb={4}>
+        <Link href="/newsletters" passHref>
+          <Box
+            sx={{
+              mb: 4,
+              display: 'flex',
+              alignItems: 'center',
+              ':hover': { color: 'red', cursor: 'pointer' }
+            }}
+          >
+            <ArrowLeftCircle />
+            <Text sx={{ fontSize: [2, 3], ml: 2 }}>Back</Text>
+          </Box>
+        </Link>
         <Content html={html} />
         <Button
           as="a"

--- a/pages/newsletters/index.js
+++ b/pages/newsletters/index.js
@@ -19,7 +19,7 @@ const Page = ({ slugs, html }) => (
       <Button
         as="a"
         href="https://github.com/hackclub/newsletters"
-        variant="outline"
+        variant="outline" 
         sx={{ color: 'muted', mt: 3 }}
       >
         <GitHub />


### PR DESCRIPTION
With the rise of Hack Club's new [community newsletters](https://github.com/hackclub/newsletter), I figured it would be a pretty cool idea if we had a page that showcased all the issues, similar to the VIP newsletters!

<img width="1490" alt="Screen Shot 2022-08-21 at 1 39 42 AM" src="https://user-images.githubusercontent.com/64022614/185777255-cd29efd2-2b65-465f-972f-91ea12100399.png">

<img width="1490" alt="Screen Shot 2022-08-21 at 1 40 08 AM" src="https://user-images.githubusercontent.com/64022614/185777282-5a5dc911-905b-49c1-96a2-a8ef71ec60d4.png">

The authors of each issue are rendered based on the contributors to the issue in the Github repository!
