### PR TITLE
Fix code and video overflow

### DIFF
--- a/lib/theme.js
+++ b/lib/theme.js
@@ -4,7 +4,8 @@ const theme = base
 
 theme.styles['p > code, li > code'] = {
   color: 'purple',
-  fontSize: '0.875em'
+  fontSize: '0.875em',
+  overflowWrap: 'break-word'
 }
 theme.styles['p > a > code, li > a > code'] = {
   color: 'red',
@@ -13,6 +14,9 @@ theme.styles['p > a > code, li > a > code'] = {
 theme.styles.pre.code = {
   ...theme.styles.pre.code,
   px: 0
+}
+theme.styles.video = {
+  width: '100%'
 }
 
 theme.cards.nav = {


### PR DESCRIPTION
I went to the [Web Chat workshop](https://workshops.hackclub.com/web_chat/) and noticed the layout was super broken on my phone.

<img width="215" alt="Screen Shot 2022-10-24 at 11 57 32 AM" src="https://user-images.githubusercontent.com/14811170/197571732-7e0c664f-af67-486d-8f9b-d53db6cba699.png">
<img width="280" alt="Screen Shot 2022-10-24 at 11 57 49 AM" src="https://user-images.githubusercontent.com/14811170/197571751-bcc3cc4d-5466-4afc-9ebe-ffa78f9ed0a8.png">

This PR fixes the overflowing `<video>` and `<code>` elements.

## After

<img width="217" alt="Screen Shot 2022-10-24 at 11 58 04 AM" src="https://user-images.githubusercontent.com/14811170/197571844-2a0155a0-6a8f-440d-95ff-6c78b29e034f.png">
<img width="244" alt="Screen Shot 2022-10-24 at 11 58 14 AM" src="https://user-images.githubusercontent.com/14811170/197571851-ab81ab1b-3667-4366-9247-4b45739548b1.png">
