### PR TITLE
Render external images in external-preview mode

### DIFF
--- a/lib/data.js
+++ b/lib/data.js
@@ -272,7 +272,7 @@ export const getWorkshopSections = async () => {
   })
 }
 
-export const getWorkshopData = async (slug, md, branch) => {
+export const getWorkshopData = async (slug, md, branch, repo) => {
   const { content, data } = matter(md)
   const authors = (data?.author || '').includes('@')
     ? data?.author
@@ -292,8 +292,8 @@ export const getWorkshopData = async (slug, md, branch) => {
   )}`
   data.bg = `/api/patterns/${slug}`
   data.editUrl = getEditUrl(`workshops/${slug}/README.md`)
-  const imgPath = branch
-    ? `https://raw.githubusercontent.com/hackclub/hackclub/${branch}`
+  const imgPath = branch || repo
+    ? `https://raw.githubusercontent.com/${repo || 'hackclub/hackclub'}/${branch || 'main'}`
     : '/content'
   const html = await markdownToHtml(content, `workshops/${slug}`, imgPath, true)
   return { data, html }

--- a/pages/external-preview/[repo]/[branch]/[slug].js
+++ b/pages/external-preview/[repo]/[branch]/[slug].js
@@ -34,7 +34,7 @@ Page.getInitialProps = async req => {
     branch,
     repo
   )
-  const { data, html } = await getWorkshopData(slug, md, branch)
+  const { data, html } = await getWorkshopData(slug, md, branch, repo)
   return { slug, data, html }
 }
 


### PR DESCRIPTION
Instead of fetching images from `githubusercontent.com/hackclub/hackclub/${branch}`, fetch from `githubusercontent.com/${repo}/${branch}` - just like markdown is.

See https://workshops.hackclub.com/external-preview/karmanyaahm/onboard/pcb_level_2/ for an example of a page that doesn't work (Inspect Element -> search for githubusercontent to find the nonexistent images).

Closes #114